### PR TITLE
Adding Spinnaker Summit SIG Proposal

### DIFF
--- a/sig-summit/README.md
+++ b/sig-summit/README.md
@@ -1,0 +1,43 @@
+# SIG: Spinnaker Summit
+
+This SIG is focused on planning and alignment for the annual Spinnaker Summit conference. 
+
+## Meetings
+
+* Regular SIG Meeting
+  * Every other Tuesday, 1 PM EST / 10AM PST
+
+## Leadership
+
+* Michael Galloway ([michaelgalloway](https://github.com/michaelgalloway))
+* Greg Comstock 
+
+## Contact
+
+* [Slack](http://spinnakerteam.slack.com/messages/spinnakersummit)
+
+## Scope
+
+*Status and Alignment*
+
+* Socialize event planning and execution updates
+
+* Spinnaker Summit goals - What we’d like to see
+
+*Talks and Activities*
+
+* Create a list of suggested talk topics
+
+* Define the talk review process
+
+* Determine non-speaking activities for the event
+
+*Engagement*
+
+* Develop community-driven communication plan and materials
+
+* Reaching out to potential speakers
+
+* Advertising the conference itself
+
+

--- a/sig-summit/README.md
+++ b/sig-summit/README.md
@@ -6,6 +6,8 @@ This SIG is focused on planning and alignment for the annual Spinnaker Summit co
 
 * Regular SIG Meeting
   * Every other Tuesday, 1 PM EST / 10AM PST
+  
+  [Agenda](https://docs.google.com/document/d/1Z65IHImNlJbYq3XvVgnWtijhWj3iUlMGG5uQudjhTe4/edit)
 
 ## Leadership
 


### PR DESCRIPTION
Trying out the new SIG lifecycle process.  

This is a request for a new SIG to bring the community into the planning and discussions for the Spinnaker Summit.