### PR TITLE
Replace Steven Kim with Andrew Phillips on SC.

### DIFF
--- a/committee-steering/README.md
+++ b/committee-steering/README.md
@@ -16,7 +16,7 @@ _TODO_
 * Matt Duftler (Google)
 * Peter Stout (Netflix)
 * Ruslan Meshenberg (Netflix)
-* Steven Kim (Google)
+* Andrew Phillips (Google)
 
 ## Contact
 


### PR DESCRIPTION
Propagating change from https://github.com/spinnaker/community/pull/21.