### PR TITLE
docs(governance): Update Approvers qualifications

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -50,12 +50,13 @@ Qualification guidelines
 * Is already fulfilling the Reviewer role
 * Belongs to an organization with significant stake in project
 * Known active participant in the community
+* Has reviewed 5 PRs of significant scope
 * Has submitted at least 5 PRs of significant scope that are merged
 * Sponsored by 2 Approvers
 
 [Current Approvers](https://github.com/spinnaker/spinnaker/blob/master/approvers.md)
 
-If you’d like to nominate yourself as an Approver, please create an [Issue in the community repository](https://github.com/spinnaker/community/issues). If you are already a Reviewer who meets the above Qualifications, you do not need to wait before submitting for Approver status.
+If you’d like to nominate yourself as an Approver, please create an [Issue in the community repository](https://github.com/spinnaker/community/issues). 
 
 ### SIG Leads
 

--- a/governance.md
+++ b/governance.md
@@ -50,8 +50,8 @@ Qualification guidelines
 * Is already fulfilling the Reviewer role
 * Belongs to an organization with significant stake in project
 * Known active participant in the community
-* Has reviewed 5 PRs of significant scope
 * Has submitted at least 5 PRs of significant scope that are merged
+* Has reviewed 5 PRs of significant scope
 * Sponsored by 2 Approvers
 
 [Current Approvers](https://github.com/spinnaker/spinnaker/blob/master/approvers.md)

--- a/governance.md
+++ b/governance.md
@@ -47,15 +47,15 @@ Duties
 
 Qualification guidelines
 
+* Is already fulfilling the Reviewer role
 * Belongs to an organization with significant stake in project
 * Known active participant in the community
 * Has submitted at least 5 PRs of significant scope that are merged
-* Has reviewed 5 PRs of significant scope
 * Sponsored by 2 Approvers
 
 [Current Approvers](https://github.com/spinnaker/spinnaker/blob/master/approvers.md)
 
-If you’d like to nominate yourself as an Approver, please create an [Issue in the community repository](https://github.com/spinnaker/community/issues). 
+If you’d like to nominate yourself as an Approver, please create an [Issue in the community repository](https://github.com/spinnaker/community/issues). If you are already a Reviewer who meets the above Qualifications, you do not need to wait before submitting for Approver status.
 
 ### SIG Leads
 


### PR DESCRIPTION
There was no explicit language that someone needs to be a Reviewer first. Also, there was no language around the process of moving from Reviewer to Approver, so I added some mentioning that there is no arbitrary timeline for moving between roles.