### PR TITLE
chore(update): update the repo readme per Docs SIG meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ If you're using Spinnaker and could not find your answer in the documentation, s
 * [#general](https://spinnakerteam.slack.com/archives/C091CCWRJ) for general questions and discussion 
 * [#dev](https://spinnakerteam.slack.com/archives/C0DPVDMQE) for help contributing to Spinnaker
 
-After engaging with the community to work through a problem , we encourage you to file an issue for the appropriate repo based if appropriate. Reasons you might file an issue include the following: 
+After engaging with the community to work through a problem, we encourage you to file an issue for the appropriate repo if you think it's needed. Reasons you might file an issue include the following: 
 
 * Your problems are due to a bug or limitation that is not documented
 * The documentation for something is confusing
 * The behavior of a feature or field is unclear
 
-File bugs or feature requests for Spinnaker [here](https://github.com/spinnaker/spinnaker/issues).
+File issues for Spinnaker [here](https://github.com/spinnaker/spinnaker/issues).
 
-File documentation issues [here](https://github.com/spinnaker/spinnaker.github.io/issues/).
+File issues for documentation [here](https://github.com/spinnaker/spinnaker.github.io/issues/).
+
+

--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ After engaging with the community to work through a problem , we encourage you t
 * Your problems are due to a bug or limitation that is not documented
 * The documentation for something is confusing
 * The behavior of a feature or field is unclear
+
+File bugs or feature requests for Spinnaker [here](https://github.com/spinnaker/spinnaker/issues).
+
+File documentation issues [here](https://github.com/spinnaker/spinnaker.github.io/issues/).

--- a/README.md
+++ b/README.md
@@ -1,19 +1,41 @@
 # Spinnaker Community
 
-Welcome to the Spinnaker community!
+Welcome to the Spinnaker Community! 
 
 This is the starting point for joining and contributing to the Spinnaker community.
 A good place to start is by viewing the [Roadmap](roadmap.md).
 
-### How the project works
+### In this Repo
+
+This repository contains the following information:
+
+* [The Spinnaker Roadmap](roadmap.md)
+* [The Special Interest Groups (SIGs)](sig-index.md) for Spinnaker
+* [Governance information](governance.md), including the members of specific groups like the Steering Committee, Technical Oversight Committee, Approvers, and Reviewers 
+* [Requests for Comments (RFCs)](rfc)
+
+### How the Project Works
 
 To learn more about the project structure and organization, please refer to the [Project's Governance](governance.md) information.
 
-### How to get involved
+### Get Involved
 
 Connect with us via:
 
 * [Slack](https://spinnakerteam.slack.com/)
-* [Community forum](https://community.spinnaker.io/)
-* [Stack Overflow](https://stackoverflow.com/questions/tagged/spinnaker)
 * [Twitter](https://twitter.com/spinnakerio)
+
+### Find Help for Spinnaker
+
+If you're using Spinnaker and could not find your answer in the documentation, start with [Slack](https://spinnakerteam.slack.com/). Many Spinnaker contributors and users are active on the Spinnaker Slack. It's a great place to get answers to questions or start a discussion about a feature or topic. Good places to begin on Slack include the following channels: 
+
+* A SIG channel if there is a relevant one, such as `#sig-security`. All SIG slack channels start with the prefix `sig`.
+* A narrowly focused channel, such as #auth
+* [#general](https://spinnakerteam.slack.com/archives/C091CCWRJ) for general questions and discussion 
+* [#dev](https://spinnakerteam.slack.com/archives/C0DPVDMQE) for help contributing to Spinnaker
+
+After engaging with the community to work through a problem , we encourage you to file an issue for the appropriate repo based if appropriate. Reasons you might file an issue include the following: 
+
+* Your problems are due to a bug or limitation that is not documented
+* The documentation for something is confusing
+* The behavior of a feature or field is unclear


### PR DESCRIPTION
We had a discussion in the Docs SIG about making the Community pages and repo more useful. This is the PR for the repo. Here's the PR for the pages: https://github.com/spinnaker/spinnaker.github.io/pull/1625

This PR does the following: 
- removes the forum and stack overflow links since they were not being actively monitored
- points people to Slack before filing an issue
- makes the repo a little more user friendly by adding `In this Repo`